### PR TITLE
enable bigger file upload size, update script for docker images, add gitignore to ignore nextcloud docker volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+nextcloud/
+proxy/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./proxy/html:/usr/share/nginx/html
       - ./proxy/certs:/etc/nginx/certs:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./uploadsize.conf:/etc/nginx/conf.d/uploadsize.conf:ro
     networks:
       - proxy-tier
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     restart: always
 
   app:
-    image: nextcloud:fpm
+    image: nextcloud:stable-fpm
     container_name: nextcloud_fpm
     links:
       - db

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+docker-compose down
+docker-compose pull
+docker-compose up -d db
+docker-compose up -d
+
+# docker rmi $(docker images --filter "dangling=true" -q --no-trunc) 
+docker images --no-trunc | grep '<none>' | awk '{ print $3 }' | xargs -r docker rmi
+
+

--- a/uploadsize.conf
+++ b/uploadsize.conf
@@ -1,0 +1,1 @@
+client_max_body_size 100G;


### PR DESCRIPTION
As described here
https://github.com/nextcloud/docker/issues/95
it would be nice to upload files that have a bigger filesize 